### PR TITLE
minifyEnabled

### DIFF
--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -32,7 +32,7 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.config
         }


### PR DESCRIPTION
[Reduce APK Size] By enabling this you are telling proguard to remove all the unused methods, instructions and slim down the classes.dex file.